### PR TITLE
feat/background

### DIFF
--- a/src/shell/executor.rs
+++ b/src/shell/executor.rs
@@ -79,6 +79,8 @@ pub fn execute_command(commands: Vec<parser::Command>) {
 
     use std::process;
 
+    // TODO: background
+
     let mut previous_stdout = None;
     let mut children = Vec::new();
 

--- a/src/shell/executor.rs
+++ b/src/shell/executor.rs
@@ -112,7 +112,14 @@ pub fn execute_command(commands: Vec<parser::Command>) {
         children.push(child);
     }
 
-    for mut child in children {
-        child.wait().expect("failed to wait child");
+    let is_background = commands.last().map(|c| c.is_background).unwrap_or(false);
+
+    if is_background {
+        let pids: Vec<u32> = children.iter().map(|c| c.id()).collect();
+        println!("[{}] {:?}", 1, pids);
+    } else {
+        for mut child in children {
+            child.wait().expect("failed to wait child");
+        }
     }
 }

--- a/src/shell/parser.rs
+++ b/src/shell/parser.rs
@@ -4,6 +4,7 @@ pub struct Command {
     pub args: Vec<String>,
     pub stdin: Option<String>,
     pub stdout: Option<String>,
+    pub is_background : bool
 }
 
 #[derive(Debug)]
@@ -65,6 +66,7 @@ fn parse_tokens(tokens: Vec<String>) -> Command {
     let mut args = Vec::new();
     let mut stdin = None;
     let mut stdout = None;
+    let mut is_background = false;
 
     let mut i = 0;
     while i < tokens.len() {
@@ -83,6 +85,8 @@ fn parse_tokens(tokens: Vec<String>) -> Command {
             } else {
                 eprintln!("<: failed to redirect")
             }
+        } else if token == "&" {
+            is_background = true;
         } else {
             args.push(token);
         }
@@ -100,6 +104,7 @@ fn parse_tokens(tokens: Vec<String>) -> Command {
         args,
         stdin,
         stdout,
+        is_background
     }
 }
 

--- a/src/shell/parser.rs
+++ b/src/shell/parser.rs
@@ -4,7 +4,7 @@ pub struct Command {
     pub args: Vec<String>,
     pub stdin: Option<String>,
     pub stdout: Option<String>,
-    pub is_background : bool
+    pub is_background: bool
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## 1. 🎯 Objective

Add support for background execution in the shell, allowing users to run commands asynchronously by appending `&`.

---

## 2. 📋 To-Do List

- [x] Detect trailing `&` in parsed input
- [x] Modify executor to handle background processes
- [x] Prevent blocking for background commands
- [x] Display process ID of backgrounded commands (optional)

---

## 3. 🛠 Implementation Details

- Updated parser to recognize and strip the `&` symbol
- Added `is_background` flag in the `Command` struct
- In `executor.rs`, used `Command::spawn()` instead of `Command::status()` for background processes
- Example usage:
  ```bash
  mysh> sleep 5 &
  [1] 12345
